### PR TITLE
✨ Add command palette with keyboard shortcuts

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,0 +1,113 @@
+import { useNavigate } from "@tanstack/react-router"
+import {
+  BookOpenIcon,
+  FileTextIcon,
+  HomeIcon,
+  PaletteIcon,
+  PlusIcon,
+  SearchIcon,
+  SettingsIcon,
+  UsersIcon,
+} from "lucide-react"
+import { useEffect, useState } from "react"
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setOpen((isOpen) => !isOpen)
+      }
+    }
+
+    document.addEventListener("keydown", down)
+    return () => document.removeEventListener("keydown", down)
+  }, [])
+
+  const runCommand = (command: () => void) => {
+    setOpen(false)
+    command()
+  }
+
+  return (
+    <CommandDialog onOpenChange={setOpen} open={open}>
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+
+        <CommandGroup heading="Navigation">
+          <CommandItem onSelect={() => runCommand(() => navigate({ to: "/dashboard" }))}>
+            <HomeIcon />
+            Dashboard
+          </CommandItem>
+          <CommandItem onSelect={() => runCommand(() => navigate({ to: "/dashboard/novels" }))}>
+            <BookOpenIcon />
+            Novels
+          </CommandItem>
+          <CommandItem onSelect={() => runCommand(() => navigate({ to: "/dashboard/ai" }))}>
+            <PaletteIcon />
+            AI Providers
+          </CommandItem>
+          <CommandItem onSelect={() => runCommand(() => navigate({ to: "/dashboard/settings" }))}>
+            <SettingsIcon />
+            Settings
+          </CommandItem>
+          <CommandItem onSelect={() => runCommand(() => navigate({ to: "/dashboard/team" }))}>
+            <UsersIcon />
+            Team
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Actions">
+          <CommandItem
+            onSelect={() =>
+              runCommand(() => {
+                // This would typically trigger a new novel creation modal
+              })
+            }
+          >
+            <PlusIcon />
+            Create New Novel
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              runCommand(() => {
+                // This would typically open a search modal
+              })
+            }
+          >
+            <SearchIcon />
+            Search Novels
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Quick Links">
+          <CommandItem onSelect={() => runCommand(() => window.open("/privacy", "_blank"))}>
+            <FileTextIcon />
+            Privacy Policy
+          </CommandItem>
+          <CommandItem onSelect={() => runCommand(() => window.open("/terms", "_blank"))}>
+            <FileTextIcon />
+            Terms of Service
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
 import AppHeader from "@/components/app-header"
+import { CommandPalette } from "@/components/command-palette"
 import Loader from "@/components/loader"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/sonner"
@@ -68,6 +69,7 @@ function RootComponent() {
             <main className="flex-1">{isFetching ? <Loader /> : <Outlet />}</main>
           </div>
         )}
+        <CommandPalette />
         <Toaster richColors />
       </ThemeProvider>
       <TanStackRouterDevtools position="bottom-left" />


### PR DESCRIPTION
## Summary
- Integrated shadcn/ui command palette component with global keyboard shortcut (Cmd+K / Ctrl+K)
- Added navigation commands for quick access to Dashboard, Novels, AI Providers, Settings, and Team pages
- Included action placeholders for creating new novels and searching
- Added quick links to Privacy Policy and Terms of Service pages

## Test plan
- [ ] Press Cmd+K (Mac) or Ctrl+K (Windows/Linux) to open command palette
- [ ] Verify all navigation commands work correctly
- [ ] Test search functionality by typing in the command input
- [ ] Confirm command palette closes after selecting an item
- [ ] Verify command palette integrates properly with existing theme system

🤖 Generated with [Claude Code](https://claude.ai/code)