### PR TITLE
Enable OpenAI provider and update AI model descriptions

### DIFF
--- a/apps/web/src/routes/dashboard/ai.tsx
+++ b/apps/web/src/routes/dashboard/ai.tsx
@@ -194,14 +194,14 @@ function AIProvidersPage() {
     {
       id: "openai",
       name: "OpenAI",
-      description: "GPT-4o, GPT-4-turbo, GPT-3.5",
-      enabled: false,
+      description: "GPT-4o, GPT-4o-mini, o1-preview, o1-mini",
+      enabled: true,
       supportsPKCE: false,
     },
     {
       id: "anthropic",
       name: "Anthropic",
-      description: "Claude-3.5-Sonnet, Claude-3-Haiku",
+      description: "Claude-4.0-Opus, Claude-4.0-Sonnet",
       enabled: true,
       supportsPKCE: false,
     },


### PR DESCRIPTION
## Summary
- Enable OpenAI provider in the AI dashboard (was previously disabled)
- Update OpenAI model descriptions to include modern models: GPT-4o, GPT-4o-mini, o1-preview, o1-mini
- Update Anthropic model descriptions to show current Claude 4.0 models: Opus and Sonnet

## Test plan
- [ ] Verify OpenAI appears in Available Providers table
- [ ] Confirm OpenAI provider can be connected with API key
- [ ] Check that model descriptions are accurately displayed
- [ ] Ensure Anthropic provider still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)